### PR TITLE
geom_alt props

### DIFF
--- a/data/421/186/727/421186727.geojson
+++ b/data/421/186/727/421186727.geojson
@@ -99,6 +99,9 @@
     },
     "wof:country":"TT",
     "wof:created":1459009489,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"17b10438780a12e354a7afd2553fda03",
     "wof:hierarchy":[
         {
@@ -109,7 +112,7 @@
         }
     ],
     "wof:id":421186727,
-    "wof:lastmodified":1566588186,
+    "wof:lastmodified":1582343813,
     "wof:name":"Tunapuna",
     "wof:parent_id":85679079,
     "wof:placetype":"locality",

--- a/data/856/322/71/85632271.geojson
+++ b/data/856/322/71/85632271.geojson
@@ -888,6 +888,7 @@
     "qs:source":"US State Department, with Natural Earth mods",
     "src:geom":"quattroshapes",
     "src:geom_alt":[
+        "naturalearth",
         "naturalearth"
     ],
     "src:lbl_centroid":"mapshaper",
@@ -940,6 +941,10 @@
     },
     "wof:country":"TT",
     "wof:country_alpha3":"TTO",
+    "wof:geom_alt":[
+        "naturalearth-display-terrestrial-zoom6",
+        "naturalearth"
+    ],
     "wof:geomhash":"0c25d760c0d00b4f2480d065d7a38a5d",
     "wof:hierarchy":[
         {
@@ -954,7 +959,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1566588157,
+    "wof:lastmodified":1582343813,
     "wof:name":"Trinidad and Tobago",
     "wof:parent_id":102191575,
     "wof:placetype":"country",

--- a/data/856/322/71/85632271.geojson
+++ b/data/856/322/71/85632271.geojson
@@ -888,7 +888,6 @@
     "qs:source":"US State Department, with Natural Earth mods",
     "src:geom":"quattroshapes",
     "src:geom_alt":[
-        "naturalearth",
         "naturalearth"
     ],
     "src:lbl_centroid":"mapshaper",
@@ -959,7 +958,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1582343813,
+    "wof:lastmodified":1583222769,
     "wof:name":"Trinidad and Tobago",
     "wof:parent_id":102191575,
     "wof:placetype":"country",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.