### PR TITLE
tt concordances, placetype local, and more

### DIFF
--- a/data/856/322/71/85632271.geojson
+++ b/data/856/322/71/85632271.geojson
@@ -1113,6 +1113,7 @@
         "hasc:id":"TT",
         "icao:code":"9Y",
         "ioc:id":"TTO",
+        "iso:code":"TT",
         "itu:id":"TRD",
         "loc:id":"n81008555",
         "m49:code":"780",
@@ -1126,6 +1127,7 @@
         "wk:page":"Trinidad and Tobago",
         "wmo:id":"TD"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"TT",
     "wof:country_alpha3":"TTO",
     "wof:geom_alt":[
@@ -1146,7 +1148,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1694639525,
+    "wof:lastmodified":1695881181,
     "wof:name":"Trinidad and Tobago",
     "wof:parent_id":102191575,
     "wof:placetype":"country",

--- a/data/856/790/25/85679025.geojson
+++ b/data/856/790/25/85679025.geojson
@@ -121,9 +121,11 @@
         "gn:id":7521940,
         "gp:id":56189856,
         "hasc:id":"TT.",
+        "iso:code":"TT-ETO",
         "qs_pg:id":892968,
         "unlc:id":"TT-ETO"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"TT",
     "wof:geomhash":"05029fba9181d407637b459b487ff08b",
     "wof:hierarchy":[
@@ -140,7 +142,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1694493126,
+    "wof:lastmodified":1695884282,
     "wof:name":"Eastern Tobago",
     "wof:parent_id":85632271,
     "wof:placetype":"region",

--- a/data/856/790/29/85679029.geojson
+++ b/data/856/790/29/85679029.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.011595,
-    "geom:area_square_m":140638723.233207,
+    "geom:area_square_m":140639060.377797,
     "geom:bbox":"-60.847524,11.143256,-60.646999,11.307976",
     "geom:latitude":11.215395,
     "geom:longitude":-60.741924,
@@ -137,12 +137,14 @@
         "gn:id":3573606,
         "gp:id":56189855,
         "hasc:id":"TT.TO",
+        "iso:code":"TT-TOB",
         "iso:id":"TT-TOB",
         "qs_pg:id":13256,
         "unlc:id":"TT-WTO"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"TT",
-    "wof:geomhash":"9f03b9053fab6c11aa5f3e2641927de7",
+    "wof:geomhash":"3807efe07f771a7bd40296535890c2f4",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -157,7 +159,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1614896191,
+    "wof:lastmodified":1695884537,
     "wof:name":"Western Tobago",
     "wof:parent_id":85632271,
     "wof:placetype":"region",

--- a/data/856/790/35/85679035.geojson
+++ b/data/856/790/35/85679035.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.011175,
-    "geom:area_square_m":135771166.403081,
+    "geom:area_square_m":135771166.403085,
     "geom:bbox":"-61.765492,10.667064,-61.487998,10.75495",
     "geom:latitude":10.711462,
     "geom:longitude":-61.576573,
@@ -257,14 +257,16 @@
         "gn:id":7521939,
         "gp:id":56189828,
         "hasc:id":"TT.DM",
+        "iso:code":"TT-DMN",
         "iso:id":"TT-DMN",
         "qs_pg:id":224050,
         "unlc:id":"TT-DMN",
         "wd:id":"Q2679107",
         "wk:page":"Diego Martin Regional Corporation"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"TT",
-    "wof:geomhash":"1c34470999e858560d5f4210c0759ca5",
+    "wof:geomhash":"74531c4644a92da5fb47ba5ad0fb233f",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -279,7 +281,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690875476,
+    "wof:lastmodified":1695884866,
     "wof:name":"Diego Martin",
     "wof:parent_id":85632271,
     "wof:placetype":"region",

--- a/data/856/790/39/85679039.geojson
+++ b/data/856/790/39/85679039.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.042667,
-    "geom:area_square_m":519347209.920205,
+    "geom:area_square_m":519348771.087562,
     "geom:bbox":"-61.9287,10.04206,-61.468801,10.247504",
     "geom:latitude":10.135912,
     "geom:longitude":-61.63781,
@@ -254,14 +254,16 @@
         "gn:id":7521945,
         "gp:id":56189835,
         "hasc:id":"TT.SI",
+        "iso:code":"TT-SIP",
         "iso:id":"TT-SIP",
         "qs_pg:id":892966,
         "unlc:id":"TT-SIP",
         "wd:id":"Q2679119",
         "wk:page":"Siparia Regional Corporation"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"TT",
-    "wof:geomhash":"d552db778740059c4c493d09616c2399",
+    "wof:geomhash":"a7452127f75650e0fccd3c25bd124116",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -276,7 +278,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690875478,
+    "wof:lastmodified":1695884866,
     "wof:name":"Siparia",
     "wof:parent_id":85632271,
     "wof:placetype":"region",

--- a/data/856/790/43/85679043.geojson
+++ b/data/856/790/43/85679043.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000829,
-    "geom:area_square_m":10075782.684942,
+    "geom:area_square_m":10075823.5641,
     "geom:bbox":"-61.295555,10.607363,-61.265221,10.653975",
     "geom:latitude":10.62533,
     "geom:longitude":-61.279166,
@@ -264,14 +264,16 @@
         "gn:id":3575052,
         "gp:id":2347116,
         "hasc:id":"TT.AR",
+        "iso:code":"TT-ARI",
         "iso:id":"TT-ARI",
         "qs_pg:id":219620,
         "unlc:id":"TT-ARI",
         "wd:id":"Q661405",
         "wk:page":"Arima"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"TT",
-    "wof:geomhash":"dec1fc8d7a634812588657e8b0bc7bd6",
+    "wof:geomhash":"79687d7559bcb343191ff5770d389889",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -286,7 +288,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690875477,
+    "wof:lastmodified":1695884866,
     "wof:name":"Arima",
     "wof:parent_id":85632271,
     "wof:placetype":"region",

--- a/data/856/790/47/85679047.geojson
+++ b/data/856/790/47/85679047.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.074274,
-    "geom:area_square_m":902570545.902439,
+    "geom:area_square_m":902569837.770142,
     "geom:bbox":"-61.239538,10.456365,-60.907297,10.845282",
     "geom:latitude":10.657935,
     "geom:longitude":-61.098224,
@@ -250,14 +250,16 @@
         "gn:id":7521944,
         "gp:id":56189833,
         "hasc:id":"TT.SN",
+        "iso:code":"TT-SGE",
         "iso:id":"TT-SGE",
         "qs_pg:id":689669,
         "unlc:id":"TT-SGE",
         "wd:id":"Q290292",
         "wk:page":"Sangre Grande Regional Corporation"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"TT",
-    "wof:geomhash":"5bdeeee32680970a6b27d67156586a8c",
+    "wof:geomhash":"8136d2e6100661520e057bed91ca268c",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -272,7 +274,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690875478,
+    "wof:lastmodified":1695884866,
     "wof:name":"Sangre Grande",
     "wof:parent_id":85632271,
     "wof:placetype":"region",

--- a/data/856/790/51/85679051.geojson
+++ b/data/856/790/51/85679051.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.07266,
-    "geom:area_square_m":884012155.603497,
+    "geom:area_square_m":884012155.603485,
     "geom:bbox":"-61.243569,10.07518,-60.961293,10.469542",
     "geom:latitude":10.28655,
     "geom:longitude":-61.108408,
@@ -255,13 +255,15 @@
         "gn:id":3574155,
         "gp:id":56189832,
         "hasc:id":"TT.MR",
+        "iso:code":"TT-MRC",
         "iso:id":"TT-MRC",
         "qs_pg:id":909771,
         "unlc:id":"TT-RCM",
         "wd:id":"Q2487249"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"TT",
-    "wof:geomhash":"3095588d21cbf536c1d16cd0dfba5ee0",
+    "wof:geomhash":"3e8b9efda51209c649e1af441f220dc8",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -276,7 +278,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690875476,
+    "wof:lastmodified":1695884866,
     "wof:name":"Rio Claro-Mayaro",
     "wof:parent_id":85632271,
     "wof:placetype":"region",

--- a/data/856/790/57/85679057.geojson
+++ b/data/856/790/57/85679057.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.017721,
-    "geom:area_square_m":215327077.49019,
+    "geom:area_square_m":215327661.876145,
     "geom:bbox":"-61.511408,10.538117,-61.333744,10.804104",
     "geom:latitude":10.685596,
     "geom:longitude":-61.43774,
@@ -255,14 +255,16 @@
         "gn:id":7521946,
         "gp:id":56189834,
         "hasc:id":"TT.SL",
+        "iso:code":"TT-SJL",
         "iso:id":"TT-SJL",
         "qs_pg:id":1131123,
         "unlc:id":"TT-SJL",
         "wd:id":"Q979608",
         "wk:page":"San Juan-Laventille Regional Corporation"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"TT",
-    "wof:geomhash":"ff0278515c9a221e8fcba0cb8e55ba14",
+    "wof:geomhash":"86cd7d2ddc14c7d63140896cd7d59f86",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -277,7 +279,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690875476,
+    "wof:lastmodified":1695884866,
     "wof:name":"San Juan-Laventille",
     "wof:parent_id":85632271,
     "wof:placetype":"region",

--- a/data/856/790/61/85679061.geojson
+++ b/data/856/790/61/85679061.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.048384,
-    "geom:area_square_m":588819187.614377,
+    "geom:area_square_m":588819187.614411,
     "geom:bbox":"-61.44149,10.069322,-61.177659,10.333065",
     "geom:latitude":10.20065,
     "geom:longitude":-61.297792,
@@ -257,14 +257,16 @@
         "gn:id":7521942,
         "gp:id":56189831,
         "hasc:id":"TT.PT",
+        "iso:code":"TT-PRT",
         "iso:id":"TT-PRT",
         "qs_pg:id":1100541,
         "unlc:id":"TT-PRT",
         "wd:id":"Q2228167",
         "wk:page":"Princes Town Regional Corporation"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"TT",
-    "wof:geomhash":"92d02dedcc76c26772bdaf84f3ce035a",
+    "wof:geomhash":"2077357b2e9952b1741e57b63b164751",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -279,7 +281,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690875475,
+    "wof:lastmodified":1695884866,
     "wof:name":"Princes Town",
     "wof:parent_id":85632271,
     "wof:placetype":"region",

--- a/data/856/790/65/85679065.geojson
+++ b/data/856/790/65/85679065.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.059349,
-    "geom:area_square_m":721712374.873844,
+    "geom:area_square_m":721712374.87388,
     "geom:bbox":"-61.487945,10.307123,-61.197138,10.591447",
     "geom:latitude":10.439186,
     "geom:longitude":-61.337579,
@@ -251,14 +251,16 @@
         "gn:id":7521938,
         "gp:id":56189827,
         "hasc:id":"TT.CT",
+        "iso:code":"TT-CTT",
         "iso:id":"TT-CTT",
         "qs_pg:id":224049,
         "unlc:id":"TT-CTT",
         "wd:id":"Q2679127",
         "wk:page":"Couva-Tabaquite-Talparo Regional Corporation"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"TT",
-    "wof:geomhash":"ac25e5d3c131b706e7dc0b28d3133595",
+    "wof:geomhash":"9006fa4108df9d12cf9a28e911339a25",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -273,7 +275,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690875477,
+    "wof:lastmodified":1695884866,
     "wof:name":"Couva-Tabaquite-Talparo",
     "wof:parent_id":85632271,
     "wof:placetype":"region",

--- a/data/856/790/69/85679069.geojson
+++ b/data/856/790/69/85679069.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.01972,
-    "geom:area_square_m":240017772.413117,
+    "geom:area_square_m":240017989.522866,
     "geom:bbox":"-61.52078,10.069322,-61.372837,10.259064",
     "geom:latitude":10.161144,
     "geom:longitude":-61.4349,
@@ -245,14 +245,16 @@
         "gn:id":7521941,
         "gp:id":56189829,
         "hasc:id":"TT.PD",
+        "iso:code":"TT-PED",
         "iso:id":"TT-PED",
         "qs_pg:id":1100531,
         "unlc:id":"TT-PED",
         "wd:id":"Q2056273",
         "wk:page":"Penal-Debe Regional Corporation"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"TT",
-    "wof:geomhash":"1f1adb3375a137a94f1acf6a48a128e4",
+    "wof:geomhash":"8daf03181f09cad20274b0f5297fe257",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -267,7 +269,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690875476,
+    "wof:lastmodified":1695884866,
     "wof:name":"Penal-Debe",
     "wof:parent_id":85632271,
     "wof:placetype":"region",

--- a/data/856/790/75/85679075.geojson
+++ b/data/856/790/75/85679075.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.00222,
-    "geom:area_square_m":27015508.365925,
+    "geom:area_square_m":27015224.21243,
     "geom:bbox":"-61.707383,10.142379,-61.629566,10.210073",
     "geom:latitude":10.172324,
     "geom:longitude":-61.66663,
@@ -258,13 +258,15 @@
         "gn:id":7521943,
         "gp:id":56189830,
         "hasc:id":"TT.PF",
+        "iso:code":"TT-PTF",
         "iso:id":"TT-PTF",
         "qs_pg:id":1100539,
         "unlc:id":"TT-PTF",
         "wd:id":"Q786957"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"TT",
-    "wof:geomhash":"3fa103b051f7ca14a7295fab5e6dfb26",
+    "wof:geomhash":"52391e4374406ee91ff1cabee2c3f24b",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -279,7 +281,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690875477,
+    "wof:lastmodified":1695884866,
     "wof:name":"Point Fortin",
     "wof:parent_id":85632271,
     "wof:placetype":"region",

--- a/data/856/790/79/85679079.geojson
+++ b/data/856/790/79/85679079.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.042979,
-    "geom:area_square_m":522230661.509349,
+    "geom:area_square_m":522230270.552624,
     "geom:bbox":"-61.428545,10.565505,-61.156959,10.804389",
     "geom:latitude":10.686597,
     "geom:longitude":-61.305191,
@@ -248,13 +248,15 @@
         "gn:id":7521947,
         "gp:id":56189836,
         "hasc:id":"TT.TP",
+        "iso:code":"TT-TUP",
         "iso:id":"TT-TUP",
         "qs_pg:id":13255,
         "unlc:id":"TT-TUP",
         "wd:id":"Q1899163"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"TT",
-    "wof:geomhash":"cf2e8fcdbb2d8effdbf58d57392a6320",
+    "wof:geomhash":"87e5e1db6ed6a22c440be1deeac8e509",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -269,7 +271,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690875478,
+    "wof:lastmodified":1695885134,
     "wof:name":"Tunapuna/Piarco",
     "wof:parent_id":85632271,
     "wof:placetype":"region",

--- a/data/856/790/83/85679083.geojson
+++ b/data/856/790/83/85679083.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.0017,
-    "geom:area_square_m":20680468.406395,
+    "geom:area_square_m":20680506.070526,
     "geom:bbox":"-61.489913,10.248005,-61.427847,10.310017",
     "geom:latitude":10.279739,
     "geom:longitude":-61.45248,
@@ -250,12 +250,14 @@
         "gn:id":3573739,
         "gp:id":20069924,
         "hasc:id":"TT.SF",
+        "iso:code":"TT-SFO",
         "iso:id":"TT-SFO",
         "qs_pg:id":418820,
         "unlc:id":"TT-SFO"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"TT",
-    "wof:geomhash":"215ddb033ef8925b0d6d64565e52df0c",
+    "wof:geomhash":"bec4a14194bdf39563476839654785fe",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -270,7 +272,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636500443,
+    "wof:lastmodified":1695884866,
     "wof:name":"San Fernando",
     "wof:parent_id":85632271,
     "wof:placetype":"region",

--- a/data/856/790/85/85679085.geojson
+++ b/data/856/790/85/85679085.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.00482,
-    "geom:area_square_m":58593996.660151,
+    "geom:area_square_m":58594014.199169,
     "geom:bbox":"-61.462295,10.503132,-61.364492,10.56628",
     "geom:latitude":10.537104,
     "geom:longitude":-61.409476,
@@ -311,14 +311,16 @@
         "gn:id":7521937,
         "gp:id":56189826,
         "hasc:id":"TT.CH",
+        "iso:code":"TT-CHA",
         "iso:id":"TT-CHA",
         "qs_pg:id":224048,
         "unlc:id":"TT-CHA",
         "wd:id":"Q1444575",
         "wk:page":"Pijawnia"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"TT",
-    "wof:geomhash":"e176a45679bfff24b93e99f6a7035f9e",
+    "wof:geomhash":"fcbfc8904be36eaedd7f0c3280e2063f",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -333,7 +335,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690875478,
+    "wof:lastmodified":1695884324,
     "wof:name":"Chaguanas",
     "wof:parent_id":85632271,
     "wof:placetype":"region",

--- a/data/856/790/93/85679093.geojson
+++ b/data/856/790/93/85679093.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.0012,
-    "geom:area_square_m":14582598.728665,
+    "geom:area_square_m":14582499.68231,
     "geom:bbox":"-61.549072,10.635641,-61.491616,10.678005",
     "geom:latitude":10.661193,
     "geom:longitude":-61.5147,
@@ -534,13 +534,15 @@
         "gn:id":3573891,
         "gp:id":2347120,
         "hasc:id":"TT.PS",
+        "iso:code":"TT-POS",
         "iso:id":"TT-POS",
         "qs_pg:id":1135359,
         "unlc:id":"TT-POS",
         "wd:id":"Q39178"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"TT",
-    "wof:geomhash":"990a9533647865ade64325000ad817e1",
+    "wof:geomhash":"bebc5203d73187b432be6f7f38c53f4d",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -555,7 +557,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690875477,
+    "wof:lastmodified":1695884324,
     "wof:name":"Port of Spain",
     "wof:parent_id":85632271,
     "wof:placetype":"region",

--- a/data/890/418/121/890418121.geojson
+++ b/data/890/418/121/890418121.geojson
@@ -60,7 +60,7 @@
         }
     ],
     "wof:id":890418121,
-    "wof:lastmodified":1694497770,
+    "wof:lastmodified":1695887123,
     "wof:name":"Ward of Siparia",
     "wof:parent_id":85679069,
     "wof:placetype":"county",

--- a/data/890/431/849/890431849.geojson
+++ b/data/890/431/849/890431849.geojson
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":890431849,
-    "wof:lastmodified":1694639681,
+    "wof:lastmodified":1695887123,
     "wof:name":"Ward of Diego Martin",
     "wof:parent_id":85679035,
     "wof:placetype":"county",

--- a/data/890/445/473/890445473.geojson
+++ b/data/890/445/473/890445473.geojson
@@ -69,7 +69,7 @@
         }
     ],
     "wof:id":890445473,
-    "wof:lastmodified":1694639681,
+    "wof:lastmodified":1695887123,
     "wof:name":"Ward of Chaguanas",
     "wof:parent_id":85679065,
     "wof:placetype":"county",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.